### PR TITLE
libgccjit: Support signed char flag

### DIFF
--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -1030,7 +1030,7 @@ jit_langhook_init (void)
   diagnostic_text_starter (global_dc) = jit_begin_diagnostic;
   diagnostic_text_finalizer (global_dc) = jit_end_diagnostic;
 
-  build_common_tree_nodes (false);
+  build_common_tree_nodes (flag_signed_char);
 
   build_common_builtin_nodes ();
 

--- a/gcc/testsuite/jit.dg/all-non-failing-tests.h
+++ b/gcc/testsuite/jit.dg/all-non-failing-tests.h
@@ -363,6 +363,13 @@
 /* test-setting-alignment.c: This can't be in the testcases array as it
    is target-specific.  */
 
+/* test-signed-char.c */
+#define create_code create_code_signed_char
+#define verify_code verify_code_signed_char
+#include "test-signed-char.c"
+#undef create_code
+#undef verify_code
+
 /* test-sizeof.c */
 #define create_code create_code_sizeof
 #define verify_code verify_code_sizeof
@@ -573,6 +580,9 @@ const struct testcase testcases[] = {
   {"reflection",
    create_code_reflection ,
    verify_code_reflection },
+  {"signed-char",
+   create_code_signed_char,
+   verify_code_signed_char},
   {"sizeof",
    create_code_sizeof,
    verify_code_sizeof},

--- a/gcc/testsuite/jit.dg/test-signed-char.c
+++ b/gcc/testsuite/jit.dg/test-signed-char.c
@@ -1,0 +1,52 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+
+#include "libgccjit.h"
+
+#include "harness.h"
+
+void
+create_code (gcc_jit_context *ctxt, void *user_data)
+{
+  /* Let's try to inject the equivalent of:
+        int test_signed_char ()
+        {
+            char val = -2;
+            return (int) val;
+        }
+    */
+  gcc_jit_type *char_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_CHAR);
+  gcc_jit_type *int_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_INT);
+
+  gcc_jit_function *test_fn =
+    gcc_jit_context_new_function (ctxt, NULL,
+				  GCC_JIT_FUNCTION_EXPORTED,
+				  int_type,
+				  "test_signed_char",
+				  0, NULL,
+				  0);
+
+  gcc_jit_block *block = gcc_jit_function_new_block(test_fn, "entry");
+
+  gcc_jit_rvalue *val = gcc_jit_context_new_rvalue_from_int (ctxt,
+    char_type, -2);
+  gcc_jit_rvalue *return_value = gcc_jit_context_new_cast (
+    ctxt, NULL, val, int_type);
+
+  gcc_jit_block_end_with_return (block, NULL, return_value);
+}
+
+void
+verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
+{
+  CHECK_NON_NULL (result);
+
+  typedef int (*fn_type) ();
+  fn_type test_signed_char =
+    (fn_type)gcc_jit_result_get_code (result, "test_signed_char");
+  CHECK_NON_NULL (test_signed_char);
+  CHECK_VALUE (test_signed_char (), -2);
+}


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001844.html

gcc/jit/ChangeLog:

	* dummy-frontend.cc (jit_langhook_init): Send flag_signed_char argument to build_common_tree_nodes.

gcc/testsuite/ChangeLog:

	* jit.dg/all-non-failing-tests.h: Add test-signed-char.c.
	* jit.dg/test-signed-char.c: New test.