### PR TITLE
libgccjit: Clear pending_assemble_externals_processed

### DIFF
--- a/gcc/toplev.cc
+++ b/gcc/toplev.cc
@@ -2433,6 +2433,7 @@ toplev::finalize (void)
   ira_costs_cc_finalize ();
   tree_cc_finalize ();
   reginfo_cc_finalize ();
+  varasm_cc_finalize ();
 
   /* save_decoded_options uses opts_obstack, so these must
      be cleaned up together.  */

--- a/gcc/varasm.cc
+++ b/gcc/varasm.cc
@@ -8834,4 +8834,12 @@ handle_vtv_comdat_section (section *sect, const_tree decl ATTRIBUTE_UNUSED)
   switch_to_comdat_section(sect, DECL_NAME (decl));
 }
 
+void
+varasm_cc_finalize (void)
+{
+#ifdef ASM_OUTPUT_EXTERNAL
+  pending_assemble_externals_processed = false;
+#endif
+}
+
 #include "gt-varasm.h"

--- a/gcc/varasm.h
+++ b/gcc/varasm.h
@@ -81,4 +81,6 @@ extern rtx assemble_trampoline_template (void);
 
 extern void switch_to_comdat_section (section *, tree);
 
+extern void varasm_cc_finalize (void);
+
 #endif  // GCC_VARASM_H


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001821.html

Without this patch, code using exception handling will fail the following assert in the function assemble_external_libcall in varasm.cc:

    gcc_assert (!pending_assemble_externals_processed)

gcc/ChangeLog:
	PR jit/113842
	* toplev.cc (toplev::finalize): Call varasm_cc_finalize.
	* varasm.cc (varasm_cc_finalize): New function to clear pending_assemble_externals_processed.
	* varasm.h (varasm_cc_finalize): New function.