### PR TITLE
libgccjit: Add support for creating temporary variables

### DIFF
--- a/gcc/jit/docs/topics/compatibility.rst
+++ b/gcc/jit/docs/topics/compatibility.rst
@@ -436,3 +436,12 @@ on functions and variables:
 ``LIBGCCJIT_ABI_32`` covers the addition of a function to get target builtins:
 
   * :func:`gcc_jit_context_get_target_builtin_function`
+
+.. _LIBGCCJIT_ABI_33:
+
+``LIBGCCJIT_ABI_33``
+--------------------
+``LIBGCCJIT_ABI_33`` covers the addition of a function to create a new
+temporary variable:
+
+  * :func:`gcc_jit_function_new_temp`

--- a/gcc/jit/docs/topics/functions.rst
+++ b/gcc/jit/docs/topics/functions.rst
@@ -190,6 +190,26 @@ Functions
    underlying string, so it is valid to pass in a pointer to an on-stack
    buffer.
 
+.. function:: gcc_jit_lvalue *\
+              gcc_jit_function_new_temp (gcc_jit_function *func,\
+                                         gcc_jit_location *loc,\
+                                         gcc_jit_type *type)
+
+   Create a new local variable within the function, of the given type.
+   This function is similar to :func:`gcc_jit_function_new_local`, but
+   it is to be used for compiler-generated variables (as opposed to
+   user-defined variables in the language to be compiled) and these
+   variables won't show up in the debug info.
+
+   The parameter ``type`` must be non-`void`.
+
+   This entrypoint was added in :ref:`LIBGCCJIT_ABI_33`; you can test
+   for its presence using
+
+   .. code-block:: c
+
+      #ifdef LIBGCCJIT_HAVE_gcc_jit_function_new_temp
+
 .. function::  size_t \
                gcc_jit_function_get_param_count (gcc_jit_function *func)
 

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -32,6 +32,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "toplev.h"
 #include "tree-cfg.h"
 #include "convert.h"
+#include "gimple-expr.h"
 #include "stor-layout.h"
 #include "print-tree.h"
 #include "gimplify.h"
@@ -2167,10 +2168,20 @@ new_local (location *loc,
 				       std::string>> &attributes)
 {
   gcc_assert (type);
-  gcc_assert (name);
-  tree inner = build_decl (UNKNOWN_LOCATION, VAR_DECL,
+  tree inner;
+  if (name)
+    inner = build_decl (UNKNOWN_LOCATION, VAR_DECL,
 			   get_identifier (name),
 			   type->as_tree ());
+  else
+  {
+    inner = build_decl (UNKNOWN_LOCATION, VAR_DECL,
+			create_tmp_var_name ("JITTMP"),
+			type->as_tree ());
+    DECL_ARTIFICIAL (inner) = 1;
+    DECL_IGNORED_P (inner) = 1;
+    DECL_NAMELESS (inner) = 1;
+  }
   DECL_CONTEXT (inner) = this->m_inner_fndecl;
 
   /* Prepend to BIND_EXPR_VARS: */

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -1523,6 +1523,10 @@ public:
 	     type *type,
 	     const char *name);
 
+  lvalue *
+  new_temp (location *loc,
+	    type *type);
+
   block*
   new_block (const char *name);
 
@@ -2417,7 +2421,12 @@ public:
   void write_to_dump (dump &d) final override;
 
 private:
-  string * make_debug_string () final override { return m_name; }
+  string * make_debug_string () final override {
+    if (m_name)
+      return m_name;
+    else
+      return m_ctxt->new_string ("temp");
+  }
   void write_reproducer (reproducer &r) final override;
   enum precedence get_precedence () const final override
   {

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -2950,6 +2950,37 @@ gcc_jit_function_new_local (gcc_jit_function *func,
 /* Public entrypoint.  See description in libgccjit.h.
 
    After error-checking, the real work is done by the
+   gcc::jit::recording::function::new_temp method in jit-recording.cc.  */
+
+gcc_jit_lvalue *
+gcc_jit_function_new_temp (gcc_jit_function *func,
+			   gcc_jit_location *loc,
+			   gcc_jit_type *type)
+{
+  RETURN_NULL_IF_FAIL (func, NULL, loc, "NULL function");
+  gcc::jit::recording::context *ctxt = func->m_ctxt;
+  JIT_LOG_FUNC (ctxt->get_logger ());
+  /* LOC can be NULL.  */
+  RETURN_NULL_IF_FAIL (func->get_kind () != GCC_JIT_FUNCTION_IMPORTED,
+		       ctxt, loc,
+		       "Cannot add temps to an imported function");
+  RETURN_NULL_IF_FAIL (type, ctxt, loc, "NULL type");
+  RETURN_NULL_IF_FAIL_PRINTF1 (
+    type->has_known_size (),
+    ctxt, loc,
+    "unknown size for temp (type: %s)",
+    type->get_debug_string ());
+  RETURN_NULL_IF_FAIL (
+    !type->is_void (),
+    ctxt, loc,
+    "void type for temp");
+
+  return (gcc_jit_lvalue *)func->new_temp (loc, type);
+}
+
+/* Public entrypoint.  See description in libgccjit.h.
+
+   After error-checking, the real work is done by the
    gcc::jit::recording::block::add_eval method in jit-recording.cc.  */
 
 void

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -1476,6 +1476,13 @@ gcc_jit_function_new_local (gcc_jit_function *func,
 			    gcc_jit_type *type,
 			    const char *name);
 
+extern gcc_jit_lvalue *
+gcc_jit_function_new_temp (gcc_jit_function *func,
+			   gcc_jit_location *loc,
+			   gcc_jit_type *type);
+
+#define LIBGCCJIT_HAVE_gcc_jit_function_new_temp
+
 /**********************************************************************
  Statement-creation.
  **********************************************************************/

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -315,3 +315,8 @@ LIBGCCJIT_ABI_32 {
   global:
     gcc_jit_context_get_target_builtin_function;
 } LIBGCCJIT_ABI_31;
+
+LIBGCCJIT_ABI_33 {
+  global:
+    gcc_jit_function_new_temp;
+} LIBGCCJIT_ABI_32;

--- a/gcc/testsuite/jit.dg/all-non-failing-tests.h
+++ b/gcc/testsuite/jit.dg/all-non-failing-tests.h
@@ -390,6 +390,9 @@
 /* test-target-builtins.c: This can't be in the testcases array as it
    is target-specific.  */
 
+/* test-temp.c: This can't be in the testcases array as it
+   is target-specific.  */
+
 /* test-string-literal.c */
 #define create_code create_code_string_literal
 #define verify_code verify_code_string_literal

--- a/gcc/testsuite/jit.dg/test-temp.c
+++ b/gcc/testsuite/jit.dg/test-temp.c
@@ -1,0 +1,56 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "libgccjit.h"
+
+#define TEST_COMPILING_TO_FILE
+#define OUTPUT_KIND      GCC_JIT_OUTPUT_KIND_ASSEMBLER
+#define OUTPUT_FILENAME  "output-of-test-test-temp.c.s"
+#include "harness.h"
+
+void
+create_code (gcc_jit_context *ctxt, void *user_data)
+{
+  /* Let's try to inject the equivalent of:
+int
+func ()
+{
+   int temp = 10;
+   return temp;
+}
+   */
+  gcc_jit_type *int_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_INT);
+
+  gcc_jit_function *func =
+    gcc_jit_context_new_function (ctxt,
+				  NULL,
+				  GCC_JIT_FUNCTION_EXPORTED,
+				  int_type,
+				  "func",
+				  0, NULL, 0);
+
+  gcc_jit_block *initial =
+    gcc_jit_function_new_block (func, "initial");
+
+  gcc_jit_lvalue *temp =
+    gcc_jit_function_new_temp (func, NULL, int_type);
+
+  gcc_jit_rvalue *ten =
+    gcc_jit_context_new_rvalue_from_int (ctxt, int_type, 10);
+  gcc_jit_block_add_assignment (initial, NULL, temp, ten);
+
+  gcc_jit_block_end_with_return(initial, NULL,
+    gcc_jit_lvalue_as_rvalue (temp));
+}
+
+void
+verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
+{
+  CHECK_NON_NULL (result);
+}
+
+/* { dg-final { jit-verify-output-file-was-created "" } } */
+/* { dg-final { jit-verify-assembler-output-not "JITTMP" } } */


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001850.html

gcc/jit/ChangeLog:

	* docs/topics/compatibility.rst (LIBGCCJIT_ABI_28): New ABI tag.
	* docs/topics/functions.rst: Document gcc_jit_function_new_temp.
	* jit-playback.cc (new_local): Add support for temporary variables.
	* jit-recording.cc (recording::function::new_temp): New method. (recording::local::write_reproducer): Support temporary variables.
	* jit-recording.h (new_temp): New method.
	* libgccjit.cc (gcc_jit_function_new_temp): New function.
	* libgccjit.h (gcc_jit_function_new_temp): New function.
	* libgccjit.map: New function.

gcc/testsuite/ChangeLog:

	* jit.dg/all-non-failing-tests.h: Mention test-temp.c.
	* jit.dg/test-temp.c: New test.
