### PR TITLE
libgccjit: Allow comparing aligned int types

### DIFF
--- a/gcc/jit/jit-common.h
+++ b/gcc/jit/jit-common.h
@@ -134,6 +134,7 @@ namespace recording {
     class statement;
       class extended_asm;
     class case_;
+    class memento_of_get_aligned;
   class top_level_asm;
 
   /* End of recording types. */

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -561,6 +561,7 @@ public:
   virtual struct_ *dyn_cast_struct () { return NULL; }
   virtual vector_type *dyn_cast_vector_type () { return NULL; }
   virtual array_type *dyn_cast_array_type () { return NULL; }
+  virtual memento_of_get_aligned *dyn_cast_aligned_type () { return NULL; }
 
   /* Is it typesafe to copy to this type from rtype?  */
   virtual bool accepts_writes_from (type *rtype)
@@ -571,6 +572,14 @@ public:
 
   virtual bool is_same_type_as (type *other)
   {
+    if (is_int ()
+		 && other->is_int ()
+		 && get_size () == other->get_size ()
+		 && is_signed () == other->is_signed ())
+    {
+      /* LHS (this) is an integer of the same size and sign as rtype.  */
+      return true;
+    }
     return this == other;
   }
 
@@ -588,6 +597,7 @@ public:
   virtual type *is_volatile () { return NULL; }
   virtual type *is_restrict () { return NULL; }
   virtual type *is_const () { return NULL; }
+  virtual type *is_aligned () { return NULL; }
   virtual type *is_array () = 0;
   virtual struct_ *is_struct () { return NULL; }
   virtual bool is_union () const { return false; }
@@ -642,13 +652,6 @@ public:
 	       accept it:  */
 	    return true;
 	  }
-      } else if (is_int ()
-		 && rtype->is_int ()
-		 && get_size () == rtype->get_size ()
-		 && is_signed () == rtype->is_signed ())
-      {
-	/* LHS (this) is an integer of the same size and sign as rtype.  */
-	return true;
       }
 
     return type::accepts_writes_from (rtype);
@@ -825,10 +828,23 @@ public:
   : decorated_type (other_type),
     m_alignment_in_bytes (alignment_in_bytes) {}
 
+  bool is_same_type_as (type *other) final override
+  {
+    if (!other->is_aligned ())
+    {
+      return m_other_type->is_same_type_as (other);
+    }
+    return m_alignment_in_bytes == other->dyn_cast_aligned_type ()->m_alignment_in_bytes
+      && m_other_type->is_same_type_as (other->is_aligned ());
+  }
+
+  type *is_aligned () final override { return m_other_type; }
+
   /* Strip off the alignment, giving the underlying type.  */
   type *unqualified () final override { return m_other_type; }
 
   void replay_into (replayer *) final override;
+  memento_of_get_aligned *dyn_cast_aligned_type () final override { return this; }
 
   array_type *dyn_cast_array_type () final override
   {

--- a/gcc/testsuite/jit.dg/test-types.c
+++ b/gcc/testsuite/jit.dg/test-types.c
@@ -486,10 +486,10 @@ verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
 
   CHECK_VALUE (z.m_FILE_ptr, stderr);
 
+  gcc_jit_type *long_type = gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_LONG);
+  gcc_jit_type *int64_type = gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_INT64_T);
   if (sizeof(long) == 8)
-    CHECK (gcc_jit_compatible_types (
-      gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_LONG),
-      gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_INT64_T)));
+    CHECK (gcc_jit_compatible_types (long_type, int64_type));
 
   CHECK_VALUE (gcc_jit_type_get_size (gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_FLOAT)), sizeof (float));
   CHECK_VALUE (gcc_jit_type_get_size (gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_DOUBLE)), sizeof (double));
@@ -501,4 +501,9 @@ verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
   gcc_jit_type *array_type1 = gcc_jit_context_new_array_type (ctxt, NULL, int_type, 2);
   gcc_jit_type *array_type2 = gcc_jit_context_new_array_type (ctxt, NULL, int_type, 2);
   CHECK (gcc_jit_compatible_types (array_type1, array_type2));
+
+  gcc_jit_type *aligned_long = gcc_jit_type_get_aligned (long_type, 4);
+  gcc_jit_type *aligned_int64 = gcc_jit_type_get_aligned (int64_type, 4);
+  if (sizeof(long) == 8)
+    CHECK (gcc_jit_compatible_types (aligned_long, aligned_int64));
 }


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001843.html

gcc/jit/ChangeLog:

	* jit-common.h: Add forward declaration of memento_of_get_aligned.
	* jit-recording.h (type::is_same_type_as): Compare integer types. (dyn_cast_aligned_type): New method. (type::is_aligned, memento_of_get_aligned::is_same_type_as, memento_of_get_aligned::is_aligned): new methods.

gcc/testsuite/ChangeLog:

	* jit.dg/test-types.c: Add checks comparing aligned types.