### PR TITLE
libgccjit: Add support for setting the comment ident

### DIFF
--- a/gcc/jit/docs/topics/compatibility.rst
+++ b/gcc/jit/docs/topics/compatibility.rst
@@ -445,3 +445,11 @@ on functions and variables:
 temporary variable:
 
   * :func:`gcc_jit_function_new_temp`
+
+.. _LIBGCCJIT_ABI_34:
+
+``LIBGCCJIT_ABI_34``
+--------------------
+``LIBGCCJIT_ABI_34`` covers the addition of
+
+ * :func:`gcc_jit_context_set_output_ident`

--- a/gcc/jit/docs/topics/contexts.rst
+++ b/gcc/jit/docs/topics/contexts.rst
@@ -604,3 +604,32 @@ Additional command-line options
    .. code-block:: c
 
       #ifdef LIBGCCJIT_HAVE_gcc_jit_context_add_driver_option
+
+Output options
+**************
+
+.. function:: void gcc_jit_context_set_output_ident (gcc_jit_context *ctxt,\
+                                                     const char* output_ident)
+
+   Set the identifier to write in the .comment section of the output file to
+   ``output_ident``.
+
+   The parameter ``output_ident`` must be non-NULL.
+
+   This only works on some target, as you can see here:
+   https://gcc.gnu.org/onlinedocs/cpp/Other-Directives.html
+
+   Analogous to:
+
+   .. code-block:: c
+
+      #ident "My comment"
+
+   in C.
+
+   This entrypoint was added in :ref:`LIBGCCJIT_ABI_28`; you can test for
+   its presence using
+
+   .. code-block:: c
+
+      #ifdef LIBGCCJIT_HAVE_gcc_jit_context_set_output_ident

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -329,6 +329,13 @@ get_type (enum gcc_jit_types type_)
   return new type (type_node);
 }
 
+void
+playback::context::
+set_output_ident (const char* ident)
+{
+  targetm.asm_out.output_ident (ident);
+}
+
 /* Construct a playback::type instance (wrapping a tree) for the given
    array type.  */
 

--- a/gcc/jit/jit-playback.h
+++ b/gcc/jit/jit-playback.h
@@ -77,6 +77,9 @@ public:
   type *
   get_type (enum gcc_jit_types type);
 
+  void
+  set_output_ident (const char* ident);
+
   type *
   new_array_type (location *loc,
 		  type *element_type,

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -1486,6 +1486,13 @@ recording::context::get_str_option (enum gcc_jit_str_option opt)
   return m_str_options[opt];
 }
 
+void
+recording::context::set_output_ident (const char *ident)
+{
+  recording::output_ident *memento = new output_ident (this, ident);
+  record (memento);
+}
+
 /* Set the given integer option for this context, or add an error if
    it's not recognized.
 
@@ -2325,6 +2332,52 @@ recording::string::write_reproducer (reproducer &)
 {
   /* Empty.  */
 }
+
+/* The implementation of class gcc::jit::recording::output_ident.  */
+
+/* Constructor for gcc::jit::recording::output_ident, allocating a
+   copy of the given text using new char[].  */
+
+recording::output_ident::output_ident (context *ctxt, const char *ident)
+: memento (ctxt)
+{
+  m_ident = ident ? xstrdup (ident) : NULL;
+}
+
+/* Destructor for gcc::jit::recording::output_ident.  */
+
+recording::output_ident::~output_ident ()
+{
+  free (m_ident);
+}
+
+/* Implementation of pure virtual hook recording::memento::replay_into
+   for recording::output_ident.  */
+
+void
+recording::output_ident::replay_into (replayer *r)
+{
+  r->set_output_ident (m_ident);
+}
+
+/* Implementation of recording::memento::make_debug_string for output_ident.  */
+
+recording::string *
+recording::output_ident::make_debug_string ()
+{
+  return m_ctxt->new_string (m_ident);
+}
+
+/* Implementation of recording::memento::write_reproducer for output_ident.  */
+
+void
+recording::output_ident::write_reproducer (reproducer &r)
+{
+  r.write ("  gcc_jit_context_set_output_ident (%s, \"%s\");",
+	   r.get_identifier (get_context ()),
+	   m_ident);
+}
+
 
 /* The implementation of class gcc::jit::recording::location.  */
 

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -267,6 +267,9 @@ public:
   get_str_option (enum gcc_jit_str_option opt);
 
   void
+  set_output_ident (const char *output_ident);
+
+  void
   set_int_option (enum gcc_jit_int_option opt,
 		  int value);
 
@@ -503,6 +506,25 @@ private:
      to avoid infinite recursion when logging all mementos: don't re-escape
      such strings.  */
   bool m_escaped;
+};
+
+class output_ident : public memento
+{
+public:
+  output_ident (context *ctxt, const char *text);
+  ~output_ident ();
+
+  void replay_into (replayer *) final override;
+
+  output_ident (const output_ident&) = delete;
+  output_ident& operator= (const output_ident&) = delete;
+
+private:
+  string * make_debug_string () final override;
+  void write_reproducer (reproducer &r) final override;
+
+private:
+  char *m_ident;
 };
 
 class location : public memento

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -3883,6 +3883,22 @@ gcc_jit_context_compile_to_file (gcc_jit_context *ctxt,
   ctxt->compile_to_file (output_kind, output_path);
 }
 
+/* Public entrypoint.  See description in libgccjit.h.
+
+   After error-checking, the real work is done by the
+   gcc::jit::recording::context::set_str_option method in
+   jit-recording.cc.  */
+
+void
+gcc_jit_context_set_output_ident (gcc_jit_context *ctxt,
+				  const char* output_ident)
+{
+  RETURN_IF_FAIL (ctxt, NULL, NULL, "NULL context");
+  RETURN_IF_FAIL (output_ident, ctxt, NULL, "NULL output_ident");
+  JIT_LOG_FUNC (ctxt->get_logger ());
+
+  ctxt->set_output_ident (output_ident);
+}
 
 /* Public entrypoint.  See description in libgccjit.h.
 

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -2153,6 +2153,12 @@ gcc_jit_lvalue_add_string_attribute (gcc_jit_lvalue *variable,
 				     enum gcc_jit_variable_attribute attribute,
 				     const char* value);
 
+extern void
+gcc_jit_context_set_output_ident (gcc_jit_context *ctxt,
+				  const char* output_ident);
+
+#define LIBGCCJIT_HAVE_gcc_jit_context_set_output_ident
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -320,3 +320,8 @@ LIBGCCJIT_ABI_33 {
   global:
     gcc_jit_function_new_temp;
 } LIBGCCJIT_ABI_32;
+
+LIBGCCJIT_ABI_34 {
+  global:
+    gcc_jit_context_set_output_ident;
+} LIBGCCJIT_ABI_33;

--- a/gcc/testsuite/jit.dg/all-non-failing-tests.h
+++ b/gcc/testsuite/jit.dg/all-non-failing-tests.h
@@ -283,6 +283,9 @@
 #undef create_code
 #undef verify_code
 
+/* test-output-ident.c: This can't be in the testcases array as it
+   is target-specific.  */
+
 /* test-quadratic.c */
 #define create_code create_code_quadratic
 #define verify_code verify_code_quadratic

--- a/gcc/testsuite/jit.dg/test-output-ident.c
+++ b/gcc/testsuite/jit.dg/test-output-ident.c
@@ -1,0 +1,23 @@
+/* { dg-do compile { target x86_64-*-* } } */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "libgccjit.h"
+
+#define TEST_COMPILING_TO_FILE
+#define OUTPUT_KIND      GCC_JIT_OUTPUT_KIND_ASSEMBLER
+#define OUTPUT_FILENAME  "output-of-test-output-ident.c.s"
+#include "harness.h"
+
+void
+create_code (gcc_jit_context *ctxt, void *user_data)
+{
+  /* Let's try to inject the equivalent of:
+     #ident "My comment"
+  */
+  gcc_jit_context_set_output_ident (ctxt, "My comment");
+}
+
+/* { dg-final { jit-verify-output-file-was-created "" } } */
+/* { dg-final { jit-verify-assembler-output ".ident	\"My comment\"" } } */


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001845.html

gcc/jit/ChangeLog:

	* docs/topics/compatibility.rst (LIBGCCJIT_ABI_28): New ABI tag.
	* docs/topics/contexts.rst: Document gcc_jit_context_set_output_ident.
	* jit-playback.cc (set_output_ident): New method.
	* jit-playback.h (set_output_ident): New method.
	* jit-recording.cc (recording::context::set_output_ident, recording::output_ident::output_ident, recording::output_ident::~output_ident, recording::output_ident::replay_into, recording::output_ident::make_debug_string, recording::output_ident::write_reproducer): New methods.
	* jit-recording.h (class output_ident): New class.
	* libgccjit.cc (gcc_jit_context_set_output_ident): New function.
	* libgccjit.h (gcc_jit_context_set_output_ident): New function.
	* libgccjit.map: New function.

gcc/testsuite/ChangeLog:

	* jit.dg/all-non-failing-tests.h: New test.
	* jit.dg/test-output-ident.c: New test.