### PR TITLE
libgccjit: Add count zeroes builtins to ensure_optimization_builtins_…

### DIFF
--- a/gcc/jit/jit-builtins.cc
+++ b/gcc/jit/jit-builtins.cc
@@ -612,6 +612,12 @@ builtins_manager::ensure_optimization_builtins_exist ()
   (void)get_builtin_function_by_id (BUILT_IN_POPCOUNT);
   (void)get_builtin_function_by_id (BUILT_IN_POPCOUNTL);
   (void)get_builtin_function_by_id (BUILT_IN_POPCOUNTLL);
+  (void)get_builtin_function_by_id (BUILT_IN_CLZ);
+  (void)get_builtin_function_by_id (BUILT_IN_CTZ);
+  (void)get_builtin_function_by_id (BUILT_IN_CLZL);
+  (void)get_builtin_function_by_id (BUILT_IN_CTZL);
+  (void)get_builtin_function_by_id (BUILT_IN_CLZLL);
+  (void)get_builtin_function_by_id (BUILT_IN_CTZLL);
 }
 
 /* Playback support.  */


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001827.html

…exist

gcc/jit/ChangeLog:

	* jit-builtins.cc (ensure_optimization_builtins_exist): Add missing builtins.