### PR TITLE
libgccjit: Do not treat warnings as errors

### DIFF
--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -3871,7 +3871,7 @@ add_error (location *loc, const char *fmt, ...)
   va_list ap;
   va_start (ap, fmt);
   m_recording_ctxt->add_error_va (loc ? loc->get_recording_loc () : NULL,
-				  fmt, ap);
+				  DK_ERROR, fmt, ap);
   va_end (ap);
 }
 
@@ -3883,13 +3883,12 @@ playback::context::
 add_error_va (location *loc, const char *fmt, va_list ap)
 {
   m_recording_ctxt->add_error_va (loc ? loc->get_recording_loc () : NULL,
-				  fmt, ap);
+				  DK_ERROR, fmt, ap);
 }
 
-/* Report a diagnostic up to the jit context as an error,
-   so that the compilation is treated as a failure.
-   For now, any kind of diagnostic is treated as an error by the jit
-   API.  */
+/* Report a diagnostic up to the jit context, so that the
+   compilation is treated as a failure if the diagnostic
+   is an error.  */
 
 void
 playback::context::
@@ -3914,7 +3913,7 @@ add_diagnostic (const char *text,
 						  false);
     }
 
-  m_recording_ctxt->add_error (rec_loc, "%s", text);
+  m_recording_ctxt->add_diagnostic (rec_loc, diagnostic.kind, "%s", text);
 }
 
 /* Dealing with the linemap API.  */

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -24,6 +24,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "coretypes.h"
 #include "target.h"
 #include "pretty-print.h"
+#include "diagnostic.h"
 #include "toplev.h"
 
 
@@ -1729,11 +1730,21 @@ recording::context::populate_target_info ()
    it to stderr, and add it to the context.  */
 
 void
+recording::context::add_diagnostic (location *loc, diagnostic_t diagnostic_kind,
+				    const char *fmt, ...)
+{
+  va_list ap;
+  va_start (ap, fmt);
+  add_error_va (loc, diagnostic_kind, fmt, ap);
+  va_end (ap);
+}
+
+void
 recording::context::add_error (location *loc, const char *fmt, ...)
 {
   va_list ap;
   va_start (ap, fmt);
-  add_error_va (loc, fmt, ap);
+  add_error_va (loc, DK_ERROR, fmt, ap);
   va_end (ap);
 }
 
@@ -1741,7 +1752,8 @@ recording::context::add_error (location *loc, const char *fmt, ...)
    it to stderr, and add it to the context.  */
 
 void
-recording::context::add_error_va (location *loc, const char *fmt, va_list ap)
+recording::context::add_error_va (location *loc, diagnostic_t diagnostic_kind,
+				  const char *fmt, va_list ap)
 {
   int len;
   char *malloced_msg;
@@ -1762,7 +1774,8 @@ recording::context::add_error_va (location *loc, const char *fmt, va_list ap)
       has_ownership = true;
     }
   if (get_logger ())
-    get_logger ()->log ("error %i: %s", m_error_count, errmsg);
+    get_logger ()->log ("%s %i: %s", get_diagnostic_kind_text(diagnostic_kind),
+			m_error_count, errmsg);
 
   const char *ctxt_progname =
     get_str_option (GCC_JIT_STR_OPTION_PROGNAME);
@@ -1774,13 +1787,15 @@ recording::context::add_error_va (location *loc, const char *fmt, va_list ap)
   if (print_errors_to_stderr)
   {
     if (loc)
-      fprintf (stderr, "%s: %s: error: %s\n",
+      fprintf (stderr, "%s: %s: %s: %s\n",
 	       ctxt_progname,
 	       loc->get_debug_string (),
+	       get_diagnostic_kind_text(diagnostic_kind),
 	       errmsg);
     else
-      fprintf (stderr, "%s: error: %s\n",
+      fprintf (stderr, "%s: %s: %s\n",
 	       ctxt_progname,
+	       get_diagnostic_kind_text(diagnostic_kind),
 	       errmsg);
   }
 
@@ -1796,7 +1811,8 @@ recording::context::add_error_va (location *loc, const char *fmt, va_list ap)
   m_last_error_str = const_cast <char *> (errmsg);
   m_owns_last_error_str = has_ownership;
 
-  m_error_count++;
+  if (diagnostic_kind == DK_ERROR)
+    m_error_count++;
 }
 
 /* Get the message for the first error that occurred on this context, or

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -24,6 +24,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "jit-common.h"
 #include "jit-logging.h"
 #include "jit-target.h"
+#include "diagnostic-core.h"
 #include "libgccjit.h"
 
 #include <string>
@@ -346,12 +347,18 @@ public:
   }
 
   void
+  add_diagnostic (location *loc, diagnostic_t diagnostic_kind,
+		  const char *fmt, ...)
+      GNU_PRINTF(4, 5);
+
+  void
   add_error (location *loc, const char *fmt, ...)
       GNU_PRINTF(3, 4);
 
   void
-  add_error_va (location *loc, const char *fmt, va_list ap)
-      GNU_PRINTF(3, 0);
+  add_error_va (location *loc, diagnostic_t diagnostic_kind, const char *fmt,
+		va_list ap)
+      GNU_PRINTF(4, 0);
 
   const char *
   get_first_error () const;

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -342,7 +342,7 @@ jit_error (gcc::jit::recording::context *ctxt,
   va_start (ap, fmt);
 
   if (ctxt)
-    ctxt->add_error_va (loc, fmt, ap);
+    ctxt->add_error_va (loc, DK_ERROR, fmt, ap);
   else
     {
       /* No context?  Send to stderr.  */

--- a/gcc/testsuite/jit.dg/test-error-array-bounds.c
+++ b/gcc/testsuite/jit.dg/test-error-array-bounds.c
@@ -64,11 +64,7 @@ create_code (gcc_jit_context *ctxt, void *user_data)
 void
 verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
 {
-  /* Verify that the diagnostic led to the context failing... */
-  CHECK_VALUE (result, NULL);
-
-  /* ...and that the message was captured by the API.  */
-  CHECK_STRING_VALUE (gcc_jit_context_get_first_error (ctxt),
-		      "array subscript 10 is above array bounds of"
-		      " 'char[10]' [-Warray-bounds=]");
+  /* Verify that the message was captured by the API.  */
+  CHECK_STRING_VALUE (gcc_jit_context_get_last_error (ctxt),
+		      "while referencing 'buffer'");
 }


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001831.html

 * [ ] Check if we should change anything regarding first_error being overwritten by warnings.

gcc/jit/ChangeLog:

	* jit-playback.cc (add_error, add_error_va): Send DK_ERROR to add_error_va. (add_diagnostic): Call add_diagnostic instead of add_error.
	* jit-recording.cc (DEFINE_DIAGNOSTIC_KIND): New define. (recording::context::add_diagnostic): New function. (recording::context::add_error): Send DK_ERROR to add_error_va. (recording::context::add_error_va): New parameter diagnostic_kind.
	* jit-recording.h (add_diagnostic): New function. (add_error_va): New parameter diagnostic_kind.
	* libgccjit.cc (jit_error): Send DK_ERROR to add_error_va.

gcc/testsuite/ChangeLog:

	* jit.dg/test-error-array-bounds.c: Fix test.