### PR TITLE
libgccjit: Allow sending a const pointer as argument

### DIFF
--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -713,6 +713,21 @@ public:
     return type::accepts_writes_from (rtype);
   }
 
+  bool is_same_type_as (type *other) final override
+  {
+    if (m_kind == GCC_JIT_TYPE_VOID_PTR)
+      {
+	if (other->is_pointer ())
+	  {
+	    /* LHS (this) is type (void *), and the RHS is a pointer:
+	       accept it:  */
+	    return true;
+	  }
+      }
+
+    return type::is_same_type_as (other);
+  }
+
   bool is_int () const final override;
   bool is_float () const final override;
   bool is_bool () const final override;
@@ -805,12 +820,6 @@ class memento_of_get_const : public decorated_type
 public:
   memento_of_get_const (type *other_type)
   : decorated_type (other_type) {}
-
-  bool accepts_writes_from (type */*rtype*/) final override
-  {
-    /* Can't write to a "const".  */
-    return false;
-  }
 
   type* copy (context* ctxt) final override
   {

--- a/gcc/testsuite/jit.dg/all-non-failing-tests.h
+++ b/gcc/testsuite/jit.dg/all-non-failing-tests.h
@@ -155,6 +155,13 @@
 #undef create_code
 #undef verify_code
 
+/* test-const-pointer-argument.c */
+#define create_code create_code_const_pointer_argument
+#define verify_code verify_code_const_pointer_argument
+#include "test-const-pointer-argument.c"
+#undef create_code
+#undef verify_code
+
 /* test-debug-strings.c */
 #define create_code create_code_debug_strings
 #define verify_code verify_code_debug_strings
@@ -537,6 +544,9 @@ const struct testcase testcases[] = {
   {"convert_vector",
    create_code_convert_vector,
    verify_code_convert_vector},
+  {"const_pointer_argument",
+   create_code_const_pointer_argument,
+   verify_code_const_pointer_argument},
   {"debug_strings",
    create_code_debug_strings,
    verify_code_debug_strings},

--- a/gcc/testsuite/jit.dg/test-const-pointer-argument.c
+++ b/gcc/testsuite/jit.dg/test-const-pointer-argument.c
@@ -1,0 +1,75 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "libgccjit.h"
+
+#include "harness.h"
+
+void
+create_code (gcc_jit_context *ctxt, void *user_data)
+{
+  /* Let's try to inject the equivalent of:
+
+     void test_ptr (void* const value)
+     {
+      return;
+     }
+
+     void main (void)
+     {
+       void* const ptr;
+       test_ptr (ptr);
+       return;
+     }
+  */
+  gcc_jit_type *void_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_VOID);
+  gcc_jit_type *real_void_ptr_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_VOID_PTR);
+  gcc_jit_type *const_real_void_ptr_type =
+    gcc_jit_type_get_const (real_void_ptr_type);
+
+  /* Build the test_ptr.  */
+  gcc_jit_param *param =
+    gcc_jit_context_new_param (ctxt, NULL, const_real_void_ptr_type, "value");
+  gcc_jit_function *test_ptr =
+    gcc_jit_context_new_function (ctxt, NULL,
+				  GCC_JIT_FUNCTION_EXPORTED,
+				  void_type,
+				  "test_ptr",
+				  1, &param,
+				  0);
+  gcc_jit_block *block = gcc_jit_function_new_block (test_ptr, NULL);
+  gcc_jit_block_end_with_void_return (block, NULL);
+
+  /* Build main.  */
+  gcc_jit_function *main =
+    gcc_jit_context_new_function (ctxt, NULL,
+				  GCC_JIT_FUNCTION_EXPORTED,
+				  void_type,
+				  "main",
+				  0, NULL,
+				  0);
+  gcc_jit_block *main_block = gcc_jit_function_new_block (main, NULL);
+
+  gcc_jit_type *void_ptr_type =
+    gcc_jit_type_get_pointer (void_type);
+  gcc_jit_type *const_void_ptr_type =
+    gcc_jit_type_get_const (void_ptr_type);
+
+  gcc_jit_lvalue *pointer =
+    gcc_jit_function_new_local (main, NULL, const_void_ptr_type, "ptr");
+  gcc_jit_rvalue *ptr_rvalue = gcc_jit_lvalue_as_rvalue (pointer);
+
+  gcc_jit_block_add_eval (main_block, NULL,
+    gcc_jit_context_new_call (ctxt, NULL, test_ptr, 1, &ptr_rvalue));
+  gcc_jit_block_end_with_void_return (main_block, NULL);
+}
+
+void
+verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
+{
+  CHECK_NON_NULL (result);
+}


### PR DESCRIPTION
ML Link: https://gcc.gnu.org/pipermail/jit/2023q4/001759.html

gcc/jit/ChangeLog:

	* jit-recording.h: Remove memento_of_get_const::accepts_writes_from.

gcc/testsuite/ChangeLog:

	* jit.dg/all-non-failing-tests.h: Add test-const-pointer-argument.c.
	* jit.dg/test-const-pointer-argument.c: New test.