### PR TITLE
libgccjit: Add option to allow special characters in function names

### DIFF
--- a/gcc/jit/docs/topics/contexts.rst
+++ b/gcc/jit/docs/topics/contexts.rst
@@ -317,12 +317,17 @@ String Options
    copy of the underlying string, so it is valid to pass in a pointer to
    an on-stack buffer.
 
-   There is just one string option specified this way:
-
    .. macro:: GCC_JIT_STR_OPTION_PROGNAME
 
       The name of the program, for use as a prefix when printing error
       messages to stderr.  If `NULL`, or default, "libgccjit.so" is used.
+
+  .. macro:: GCC_JIT_STR_OPTION_SPECIAL_CHARS_IN_FUNC_NAMES
+
+      Alphabetic ASCII characters and underscores are always valid. Numeric
+      ASCII characters are always valid after the initial character of the
+      string. Use this entrypoint to specify additional ASCII characters that
+      are valid throughout function names (ex.: ".$").
 
 Boolean options
 ***************

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -1377,6 +1377,18 @@ recording::context::set_str_option (enum gcc_jit_str_option opt,
   log_str_option (opt);
 }
 
+const char*
+recording::context::get_str_option (enum gcc_jit_str_option opt)
+{
+  if (opt < 0 || opt >= GCC_JIT_NUM_STR_OPTIONS)
+    {
+      add_error (NULL,
+		 "unrecognized (enum gcc_jit_str_option) value: %i", opt);
+      return NULL;
+    }
+  return m_str_options[opt];
+}
+
 /* Set the given integer option for this context, or add an error if
    it's not recognized.
 
@@ -1718,7 +1730,8 @@ recording::context::dump_to_file (const char *path, bool update_locations)
 
 static const char * const
  str_option_reproducer_strings[GCC_JIT_NUM_STR_OPTIONS] = {
-  "GCC_JIT_STR_OPTION_PROGNAME"
+  "GCC_JIT_STR_OPTION_PROGNAME",
+  "GCC_JIT_STR_OPTION_SPECIAL_CHARS_IN_FUNC_NAMES",
 };
 
 static const char * const
@@ -1735,7 +1748,7 @@ static const char * const
   "GCC_JIT_BOOL_OPTION_DUMP_SUMMARY",
   "GCC_JIT_BOOL_OPTION_DUMP_EVERYTHING",
   "GCC_JIT_BOOL_OPTION_SELFCHECK_GC",
-  "GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES"
+  "GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES",
 };
 
 static const char * const

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -239,6 +239,9 @@ public:
   set_str_option (enum gcc_jit_str_option opt,
 		  const char *value);
 
+  const char*
+  get_str_option (enum gcc_jit_str_option opt);
+
   void
   set_int_option (enum gcc_jit_int_option opt,
 		  int value);

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -1191,10 +1191,13 @@ gcc_jit_context_new_function (gcc_jit_context *ctxt,
      Eventually we'll need some way to interact with e.g. C++ name
      mangling.  */
   {
+    const char* special_chars_allowed
+      = ctxt->get_str_option (GCC_JIT_STR_OPTION_SPECIAL_CHARS_IN_FUNC_NAMES);
     /* Leading char: */
     char ch = *name;
     RETURN_NULL_IF_FAIL_PRINTF2 (
-	ISALPHA (ch) || ch == '_',
+	ISALPHA (ch) || ch == '_' || (special_chars_allowed
+	  && strchr (special_chars_allowed, ch)),
 	ctxt, loc,
 	"name \"%s\" contains invalid character: '%c'",
 	name, ch);
@@ -1202,7 +1205,8 @@ gcc_jit_context_new_function (gcc_jit_context *ctxt,
     for (const char *ptr = name + 1; (ch = *ptr); ptr++)
       {
 	RETURN_NULL_IF_FAIL_PRINTF2 (
-	  ISALNUM (ch) || ch == '_',
+	  ISALNUM (ch) || ch == '_' || (special_chars_allowed
+	    && strchr (special_chars_allowed, ch)),
 	  ctxt, loc,
 	  "name \"%s\" contains invalid character: '%c'",
 	  name, ch);

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -177,6 +177,9 @@ enum gcc_jit_str_option
      messages to stderr.  If NULL, or default, "libgccjit.so" is used.  */
   GCC_JIT_STR_OPTION_PROGNAME,
 
+  /* Special characters to allow in function names.  */
+  GCC_JIT_STR_OPTION_SPECIAL_CHARS_IN_FUNC_NAMES,
+
   GCC_JIT_NUM_STR_OPTIONS
 };
 

--- a/gcc/testsuite/jit.dg/test-special-chars.c
+++ b/gcc/testsuite/jit.dg/test-special-chars.c
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "libgccjit.h"
+
+#include "harness.h"
+
+void
+create_code (gcc_jit_context *ctxt, void *user_data)
+{
+  gcc_jit_context_set_str_option (ctxt,
+    GCC_JIT_STR_OPTION_SPECIAL_CHARS_IN_FUNC_NAMES, "$.");
+
+  /* Let's try to inject the equivalent of:
+       void
+       name$with.special_chars (void)
+       {
+       }
+   */
+  gcc_jit_type *void_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_VOID);
+
+  /* Build the test_fn.  */
+  gcc_jit_function *test_fn =
+    gcc_jit_context_new_function (ctxt, NULL,
+				  GCC_JIT_FUNCTION_EXPORTED,
+				  void_type,
+				  "name$with.special_chars",
+				  0, NULL,
+				  0);
+
+  gcc_jit_block *block = gcc_jit_function_new_block (test_fn, NULL);
+  gcc_jit_block_end_with_void_return (
+    block, NULL);
+}
+
+void
+verify_code (gcc_jit_context *ctxt, gcc_jit_result *result)
+{
+  CHECK_NON_NULL (result);
+}


### PR DESCRIPTION
ML link: https://gcc.gnu.org/pipermail/jit/2024q1/001851.html

 * [ ] use in rustc_codegen_gcc to make sure everything works.

gcc/jit/ChangeLog:

	* docs/topics/contexts.rst: Add documentation for new option.
	* jit-recording.cc (recording::context::get_str_option): New method.
	* jit-recording.h (get_str_option): New method.
	* libgccjit.cc (gcc_jit_context_new_function): Allow special characters in function names.
	* libgccjit.h (enum gcc_jit_str_option): New option.

gcc/testsuite/ChangeLog:

	* jit.dg/test-special-chars.c: New test.