### PR TITLE
libgccjit: Support more target builtin types

### DIFF
--- a/gcc/jit/docs/topics/compatibility.rst
+++ b/gcc/jit/docs/topics/compatibility.rst
@@ -466,3 +466,11 @@ information:
   * :func:`gcc_jit_target_info_cpu_supports`
   * :func:`gcc_jit_target_info_arch`
   * :func:`gcc_jit_target_info_supports_target_dependent_type`
+
+.. _LIBGCCJIT_ABI_36:
+
+``LIBGCCJIT_ABI_36``
+--------------------
+``LIBGCCJIT_ABI_36`` covers the addition of
+
+ * :func:`gcc_jit_context_set_abort_on_unsupported_target_builtin`

--- a/gcc/jit/docs/topics/contexts.rst
+++ b/gcc/jit/docs/topics/contexts.rst
@@ -509,6 +509,22 @@ Boolean options
 
       #ifdef LIBGCCJIT_HAVE_gcc_jit_context_set_bool_print_errors_to_stderr
 
+.. function:: void \
+              gcc_jit_context_set_abort_on_unsupported_target_builtin (gcc_jit_context *ctxt)
+
+   By default, libgccjit will silently ignore when a target builtin has an
+   unsupported type.
+
+   This entrypoint can be used to make it abort when the specified context
+   encounters such a target builtin.
+
+   This entrypoint was added in :ref:`LIBGCCJIT_ABI_36`; you can test for
+   its presence using
+
+   .. code-block:: c
+
+      #ifdef LIBGCCJIT_HAVE_gcc_jit_context_set_abort_on_unsupported_target_builtin
+
 Integer options
 ***************
 

--- a/gcc/jit/jit-playback.h
+++ b/gcc/jit/jit-playback.h
@@ -340,6 +340,11 @@ public:
     return info;
   }
 
+  bool get_abort_on_unsupported_target_builtin () const
+  {
+    return m_recording_ctxt->get_abort_on_unsupported_target_builtin ();
+  }
+
 private:
   void dump_generated_code ();
 

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -1498,6 +1498,18 @@ recording::context::set_output_ident (const char *ident)
   record (memento);
 }
 
+bool
+recording::context::get_abort_on_unsupported_target_builtin ()
+{
+  return m_abort_on_unsupported_target_builtin;
+}
+
+void
+recording::context::set_abort_on_unsupported_target_builtin ()
+{
+  m_abort_on_unsupported_target_builtin = true;
+}
+
 /* Set the given integer option for this context, or add an error if
    it's not recognized.
 

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -270,6 +270,12 @@ public:
   void
   set_output_ident (const char *output_ident);
 
+  bool
+  get_abort_on_unsupported_target_builtin ();
+
+  void
+  set_abort_on_unsupported_target_builtin ();
+
   void
   set_int_option (enum gcc_jit_int_option opt,
 		  int value);
@@ -424,6 +430,7 @@ private:
   type *m_FILE_type;
 
   bool m_populated_target_info = false;
+  bool m_abort_on_unsupported_target_builtin = false;
 
   builtins_manager *m_builtins_manager; // lazily created
 

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -3951,6 +3951,14 @@ gcc_jit_target_info_supports_target_dependent_type (gcc_jit_target_info *info,
     != info->m_supported_target_dependent_types.end ();
 }
 
+void
+gcc_jit_context_set_abort_on_unsupported_target_builtin (gcc_jit_context *ctxt)
+{
+  RETURN_IF_FAIL (ctxt, NULL, NULL, "NULL context");
+
+  ctxt->set_abort_on_unsupported_target_builtin ();
+}
+
 /* Public entrypoint.  See description in libgccjit.h.
 
    After error-checking, the real work is done by the

--- a/gcc/jit/libgccjit.exports
+++ b/gcc/jit/libgccjit.exports
@@ -239,16 +239,25 @@ _gcc_jit_global_set_readonly
 # LIBGCCJIT_ABI_30
 _gcc_jit_context_convert_vector
 
-# LIBGCCJIT_ABI_31 
+# LIBGCCJIT_ABI_31
 _gcc_jit_context_new_vector_access
 _gcc_jit_context_new_rvalue_vector_perm
 
-# LIBGCCJIT_ABI_32 
+# LIBGCCJIT_ABI_32
 _gcc_jit_context_get_target_builtin_function
 
-# LIBGCCJIT_ABI_33 
+# LIBGCCJIT_ABI_33
 _gcc_jit_function_new_temp
 
-# LIBGCCJIT_ABI_34 
+# LIBGCCJIT_ABI_34
 _gcc_jit_context_set_output_ident
 
+# LIBGCCJIT_ABI_35
+_gcc_jit_context_get_target_info
+_gcc_jit_target_info_release
+_gcc_jit_target_info_cpu_supports
+_gcc_jit_target_info_arch
+_gcc_jit_target_info_supports_target_dependent_type
+
+# LIBGCCJIT_ABI_36
+_gcc_jit_context_set_abort_on_unsupported_target_builtin

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -2216,6 +2216,11 @@ gcc_jit_context_set_output_ident (gcc_jit_context *ctxt,
 
 #define LIBGCCJIT_HAVE_gcc_jit_context_set_output_ident
 
+extern void
+gcc_jit_context_set_abort_on_unsupported_target_builtin (gcc_jit_context *ctxt);
+
+#define LIBGCCJIT_HAVE_gcc_jit_context_set_abort_on_unsupported_target_builtin
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -334,3 +334,8 @@ LIBGCCJIT_ABI_35 {
     gcc_jit_target_info_arch;
     gcc_jit_target_info_supports_target_dependent_type;
 } LIBGCCJIT_ABI_34;
+
+LIBGCCJIT_ABI_36 {
+  global:
+    gcc_jit_context_set_abort_on_unsupported_target_builtin;
+} LIBGCCJIT_ABI_35;


### PR DESCRIPTION
This also adds option to abort on unsupported type in order to be able
to detect new unsupported types more easily.

gcc/jit/ChangeLog:
	PR jit/117886
	* dummy-frontend.cc (jit_abort_on_unsupported_target_builtin):
	New variable
	* libgccjit.cc (jit_abort_on_unsupported_target_builtin): New
	variable.
	(gcc_jit_set_abort_on_unsupported_target_builtin): New function.
	* libgccjit.h (gcc_jit_set_abort_on_unsupported_target_builtin):
	New function.
	* libgccjit.map (LIBGCCJIT_ABI_35): New ABI tag.
	* docs/topics/compatibility.rst (LIBGCCJIT_ABI_35): New ABI tag.
	* docs/topics/contexts.rst: Document new function.